### PR TITLE
Read chunk size, chunk inserts and timeouts from config

### DIFF
--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -30,8 +30,8 @@ else:
     locale.setlocale(locale.LC_ALL, '')
 
 MAX_CONTENT_LENGTH = web.app.config.get('MAX_CONTENT_LENGTH') or 10485760
-CHUNK_SIZE = 16 * 1024  # 16kb
-DOWNLOAD_TIMEOUT = 30
+CHUNK_SIZE = web.app.config.get('CHUNK_SIZE') or 16384
+DOWNLOAD_TIMEOUT = web.app.config.get('DOWNLOAD_TIMEOUT') or 30
 
 if web.app.config.get('SSL_VERIFY') in ['False', 'FALSE', '0', False, 0]:
     SSL_VERIFY = False

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -31,6 +31,7 @@ else:
 
 MAX_CONTENT_LENGTH = web.app.config.get('MAX_CONTENT_LENGTH') or 10485760
 CHUNK_SIZE = web.app.config.get('CHUNK_SIZE') or 16384
+CHUNK_INSERT_ROWS = web.app.config.get('CHUNK_INSERT_ROWS') or 250
 DOWNLOAD_TIMEOUT = web.app.config.get('DOWNLOAD_TIMEOUT') or 30
 
 if web.app.config.get('SSL_VERIFY') in ['False', 'FALSE', '0', False, 0]:
@@ -503,7 +504,7 @@ def push_to_datastore(task_id, input, dry_run=False):
         return headers_dicts, result
 
     count = 0
-    for i, chunk in enumerate(chunky(result, 250)):
+    for i, chunk in enumerate(chunky(result, CHUNK_INSERT_ROWS)):
         records, is_it_the_last_chunk = chunk
         count += len(records)
         logger.info('Saving chunk {number} {is_last}'.format(


### PR DESCRIPTION
Add the ability to configure the way datapusher reads and inserts data into CKAN by reading CHUNK_SIZE, CHUNK_INSERT_ROWS and DOWNLOAD_TIMEOUT from config so that they can be loaded in during runtime through environment variables.