### PR TITLE
datapusher - empty header bugfix

### DIFF
--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -471,7 +471,8 @@ def push_to_datastore(task_id, input, dry_run=False):
 
     row_set.register_processor(messytables.types_processor(types))
 
-    headers = [header.strip() for header in headers if header.strip()]
+    # when cleaning headers, we should also clean corresponding types
+    headers, types = zip(*[(header.strip(), typ) for header, typ in zip(headers, types) if header.strip()])
     headers_set = set(headers)
 
     def row_iterator():

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -487,7 +487,7 @@ def push_to_datastore(task_id, input, dry_run=False):
                     continue
                 if isinstance(cell.value, str):
                     try:
-                        data_row[column_name] = cell.value.encode('latin-5').decode('utf-8')
+                        data_row[column_name] = cell.value.encode('latin5').decode('utf-8')
                     except (UnicodeDecodeError, UnicodeEncodeError):
                         data_row[column_name] = cell.value
                 else:

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -471,6 +471,9 @@ def push_to_datastore(task_id, input, dry_run=False):
 
     row_set.register_processor(messytables.types_processor(types))
 
+    # Save column A
+    if headers and headers[0].strip() == '':
+        headers[0] = 'column_0'
     # when cleaning headers, we should also clean corresponding types
     headers, types = zip(*[(header.strip(), typ) for header, typ in zip(headers, types) if header.strip()])
     headers_set = set(headers)
@@ -484,7 +487,7 @@ def push_to_datastore(task_id, input, dry_run=False):
                     continue
                 if isinstance(cell.value, str):
                     try:
-                        data_row[column_name] = cell.value.encode('latin-1').decode('utf-8')
+                        data_row[column_name] = cell.value.encode('latin-5').decode('utf-8')
                     except (UnicodeDecodeError, UnicodeEncodeError):
                         data_row[column_name] = cell.value
                 else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ argparse
 ckanserviceprovider==0.0.10
 html5lib==1.0.1
 messytables==0.15.2
+xlrd==1.2.0
 certifi
 requests[security]==2.24.0


### PR DESCRIPTION
if there are empty cells in the header, 
types and headers lists get out of sync when cleaning only the headers list
creates type errors at db